### PR TITLE
Remove emoji slider in favour of dropdown box

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,8 +84,6 @@ html, body {
   margin: 0 auto;
 }
 
-
-
 /* ## DRAWING CUSTOMISATIONS ## */
 
 .drawings-wrapper {
@@ -236,39 +234,5 @@ $loadbgcolour: #85144B;
 .panel-heading {
   h2 {
     text-align: center;
-  }
-}
-
-$emotions: (
-  'joyous' : '\1F602',
-  'happy' : '\1F60A',
-  'neutral' : '\1F610',
-  'sad' : '\1F61E',
-  'tragic' : '\1F622'
-);
-
-.ranger{
-  &-label{
-    display: none;
-  }
-  &-group{
-    text-align: center;
-    @each $emotion, $emoji in $emotions {
-      &[data-mood="#{$emotion}"]{
-        .ranger-emoji:after{
-          content: map-get($emotions,$emotion);
-        }
-      }
-    }
-  }
-  &-emoji{
-    &:after{
-      content: '.';
-      display: inline-block;
-      width: 1em;
-      margin-bottom: 20px;
-      line-height: 1em;
-      font-size: 6em;
-    }
   }
 }

--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -20,9 +20,9 @@ module DrawingsHelper
   end
 
   def mood_select_box
-    # Example output: [ ["1 😢", 1], ["2", 2] ... ["9", 9] ["10 😃", 10] ]
+    # Example output: [ ["1 (sad face)", 1], ["2", 2] ... ["9", 9] ["10 (happy face)", 10] ]
     selections = [].tap do |arr|
-      (1..10).each { |n| arr << ["#{n}", n] }
+      (1..10).each { |n| arr << [n.to_s, n] }
     end
     selections[0][0] += " 😢"
     selections[-1][0] += " 😃"

--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -18,4 +18,14 @@ module DrawingsHelper
       Drawing.statuses.keys.each { |s| arr << [s, s] }
     end
   end
+
+  def mood_select_box
+    # Example output: [ ["1 😢", 1], ["2", 2] ... ["9", 9] ["10 😃", 10] ]
+    selections = [].tap do |arr|
+      (1..10).each { |n| arr << ["#{n}", n] }
+    end
+    selections[0][0] += " 😢"
+    selections[-1][0] += " 😃"
+    selections
+  end
 end

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -19,7 +19,7 @@
             .form-group.text-center
               = f.input :subject_matter, collection: ["Home / Country of origin", "Transit", "Camp life", "Future hopes / destination"], label: false, required: true, prompt: "Subject matter of drawing"
             .form-group.text-center
-              = f.input :mood_rating, as: :select, collection: [["1 🙁", 1], ["2", 2], ["3", 3], ["4", 4], ["5", 5], ["6", 6], ["7", 7], ["8", 8], ["9", 9], ["10 😃", 10],], include_blank: "How would you rate the mood of the picture from 1 (sad/tragic) to 10 (happy/joyful)", label: false
+              = f.input :mood_rating, as: :select, collection: mood_select_box, include_blank: "How would you rate the mood of the picture from 1 (sad/tragic) to 10 (happy/joyful)", label: false
             .form-group.text-center
               = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: false, include_blank: "Country picture was drawn in", class: 'form-control'
 

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -19,12 +19,7 @@
             .form-group.text-center
               = f.input :subject_matter, collection: ["Home / Country of origin", "Transit", "Camp life", "Future hopes / destination"], label: false, required: true, prompt: "Subject matter of drawing"
             .form-group.text-center
-              .ranger-group
-                .ranger-emoji
-                %label_tag.ranger-label{:for => "range"} Range
-                %input.ranger-range#range{:type => "range", :name => "range", :min => "0", :max => "4", :step => "1", :value => "2"}
-
-              = f.input :mood_rating, type: 'number', required: true, label: false, placeholder: 'Mood rating (1 to 10)'
+              = f.input :mood_rating, as: :select, collection: [["1 🙁", 1], ["2", 2], ["3", 3], ["4", 4], ["5", 5], ["6", 6], ["7", 7], ["8", 8], ["9", 9], ["10 😃", 10],], include_blank: "How would you rate the mood of the picture from 1 (sad/tragic) to 10 (happy/joyful)", label: false
             .form-group.text-center
               = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: false, include_blank: "Country picture was drawn in", class: 'form-control'
 
@@ -43,18 +38,3 @@
               = f.input :status, collection: radio_statuses, label_method: lambda {|k| k.last.capitalize }, as: :radio_buttons, required: true, label: false
             .form-group.text-center
               = f.button :submit, class: 'btn-success btn-block'
-
-
-:javascript
-  var ranger = function($elem) {
-    var $parent = $elem.parent(),
-        moods = ["joyous","happy","neutral", "sad","tragic"],
-        rangeVal = parseInt($elem.val());
-        defaultMood = rangeVal;
-    $parent.attr("data-mood",moods[defaultMood]);
-    $elem.change(function(){
-      rangeVal = parseInt($elem.val());
-      $parent.attr('data-mood',moods[rangeVal]);
-    });
-  }
-  ranger($('.ranger-range'));


### PR DESCRIPTION
Address #14 and #32

Spent a bit of time trying to hook up the emoji slider (which will have required JS tweaks to make it a 1-10 scale also), or create a new slider.

Took too long, and then we have the issue of accessibility on mobile devices also, so just replaced with a simple dropdown

@krissy, some Qs for you:
1. The `collection:` as an array of arrays looks messy, but necessary to show the emojis, but not commit them as values. Any way you would tidy this up.
2. Having emojis in the code - good?/bad?/whatever?
~~3. Finally, this removes the validation on all data points for the drawings. Ok for now, or you want me to leave this for a later PR, as will impact your tests/is not really the right PR for it?~~

![image](https://cloud.githubusercontent.com/assets/4599695/17464227/f69f7844-5cd1-11e6-9828-e7236b0a2d70.png)
