### PR TITLE
[#39] Add completion status to drawings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_script:
 script:
   - RAILS_ENV=test bundle exec rake db:migrate
   - bundle exec rspec spec
-  - bundle exec rubocop --config .rubocop.yml app/models/ app/controllers/ app/helpers/ spec/
+  - bundle exec rubocop --config .rubocop.yml app/models/ app/controllers/ app/helpers/ config/initializers/ spec/
 services:
   - postgresql

--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -61,10 +61,10 @@ class DrawingsController < ApplicationController
   end
 
   def drawing_params
-    params.require(:drawing).permit(:image, :description, :gender, :age, :mood_rating, :subject_matter, :story, :country)
+    params.require(:drawing).permit(:image, :description, :gender, :age, :mood_rating, :subject_matter, :story, :country, :status)
   end
 
   def set_drawing
-    @drawing = Drawing.find(params[:id])
+    @drawing ||= Drawing.find(params[:id])
   end
 end

--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -11,4 +11,11 @@ module DrawingsHelper
     index_view = current_page?(root_path) || current_page?(controller: "drawings", action: "index")
     index_view ? "col-xs-6 col-sm-4" : "drawings-full"
   end
+
+  def radio_statuses
+    # Example output: [ ["status1", "status1"], ["status2", "status2"] ]
+    [].tap do |arr|
+      Drawing.statuses.keys.each { |s| arr << [s, s] }
+    end
+  end
 end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -1,9 +1,12 @@
 class Drawing < ActiveRecord::Base
+  enum status: %i(pending complete)
+
   validates :image, presence: true
   validates :age, presence: true, numericality: { only_integer: true }
   validates :gender, presence: true
   validates :subject_matter, presence: true
   validates :mood_rating, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
+  validates :status, presence: true
 
   has_attached_file :image, styles: { medium: "640x" }
   validates_attachment_content_type :image, content_type: %r{\Aimage\/.*\Z}

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -29,7 +29,10 @@
 
               = f.input :mood_rating, type: 'number', required: true, label: false, placeholder: 'Mood rating (1 to 10)'
             .form-group.text-center
-              = f.input :country, priority: TOP_COUNTRIES, selected: (current_user.country if @drawing.new_record?), label: false, include_blank: "Country picture was drawn in", class: 'form-control'
+              = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: false, include_blank: "Country picture was drawn in", class: 'form-control'
+            .form-group.text-center
+              %label_tag{for: "status"} Status (leave this as Pending if you need to enter required details later)
+              = f.input :status, collection: radio_statuses, label_method: lambda {|k| k.last.capitalize }, as: :radio_buttons, required: true, label: false
             .form-group.text-center
               = f.button :submit, class: 'btn-success btn-block'
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,1 +1,1 @@
-TOP_COUNTRIES = %w(GR HU RS)
+TOP_COUNTRIES = %w(GR HU RS).freeze

--- a/db/migrate/20160807145411_add_status_to_drawings.rb
+++ b/db/migrate/20160807145411_add_status_to_drawings.rb
@@ -1,0 +1,5 @@
+class AddStatusToDrawings < ActiveRecord::Migration
+  def change
+    add_column :drawings, :status, :integer, default: 0, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160806150135) do
+ActiveRecord::Schema.define(version: 20160807145411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "drawings", force: :cascade do |t|
     t.string   "description"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.string   "image_file_name"
     t.string   "image_content_type"
     t.integer  "image_file_size"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20160806150135) do
     t.string   "subject_matter"
     t.text     "story"
     t.string   "country"
+    t.integer  "status",             default: 0
   end
 
   add_index "drawings", ["user_id"], name: "index_drawings_on_user_id", using: :btree

--- a/spec/factories/drawings.rb
+++ b/spec/factories/drawings.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     subject_matter "Camp life"
     story "Context of the drawing, e.g. child's back story, cultural notes"
     country "GR"
+    status "complete"
 
     user
   end

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Drawing, type: :model do
   describe "validations" do
     context "presence" do
-      %i(image age gender subject_matter mood_rating).each do |attr|
+      %i(image age gender subject_matter mood_rating status).each do |attr|
         it { is_expected.to validate_presence_of attr }
       end
     end
@@ -19,5 +19,7 @@ RSpec.describe Drawing, type: :model do
       is_expected.to validate_numericality_of(:mood_rating)
         .is_less_than_or_equal_to(10)
     end
+
+    it { is_expected.to define_enum_for(:status).with(%i(pending complete)) }
   end
 end


### PR DESCRIPTION
**Addresses #39**
# What this does

Adds mandatory completion statuses (currently `pending` and `completed`) to drawings, to cater for cases field workers may need to split up image uploading and data entry. Need to improve UI for this later.

Also fixes some small bugs and linting bits.
## Screenshots

<img width="805" alt="screen shot 2016-08-07 at 18 49 38" src="https://cloud.githubusercontent.com/assets/574526/17464166/c10e4d7e-5ccf-11e6-9151-b8a37343e07c.png">
