### PR TITLE
[#49] Categorise fields (drawing vs artist data), make drawing data mandatory when marked complete

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,6 +151,13 @@ html, body {
   margin: 0px auto;
 }
 
+.drawing-status-pending {
+  color: #CB6264;
+  font-weight: 500;
+  font-size: 0.9em;
+  padding-top: 5px;
+}
+
 .drawing-bottom {
   .user-name, .comment-content {
     display: inline;

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -2,11 +2,17 @@ class Drawing < ActiveRecord::Base
   enum status: %i(pending complete)
 
   validates :image, presence: true
-  validates :age, presence: true, numericality: { only_integer: true }
-  validates :gender, presence: true
-  validates :subject_matter, presence: true
-  validates :mood_rating, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
   validates :status, presence: true
+
+  with_options if: :complete? do |complete|
+    complete.validates :description, presence: true
+    complete.validates :subject_matter, presence: true
+    complete.validates :mood_rating, presence: true
+    complete.validates :country, presence: true
+  end
+
+  validates :age, numericality: { only_integer: true }, allow_nil: true
+  validates :mood_rating, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }, allow_nil: true
 
   has_attached_file :image, styles: { medium: "640x" }
   validates_attachment_content_type :image, content_type: %r{\Aimage\/.*\Z}

--- a/app/views/drawings/_drawing.html.haml
+++ b/app/views/drawings/_drawing.html.haml
@@ -19,3 +19,6 @@
             - if drawing.country.present?
               drawn in
               = ISO3166::Country.find_country_by_alpha2(drawing.country).name
+          - if drawing.pending?
+            .drawing-status-pending
+              = "Pending".upcase

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -11,14 +11,11 @@
             .form-group.text-center
               %h4 Upload an image (this is required):
               = f.input :image, label: false, required: true, input_html: { onChange: 'loadFile(event)' }
+
+            .h4 Details of drawing (required when marked complete)
+
             .form-group.text-center
-              = f.input :description, label: false, placeholder: 'The description, e.g. Children play'
-            .form-group.text-center
-              = f.input :age, type: 'number', label: false, required: true, placeholder: 'Age of child'
-            .form-group.text-center
-              = f.input :gender, collection: ["Female", "Male"], label: false, required: true, prompt: "Gender of child"
-            .form-group.text-center
-              = f.input :story, label: false, required: false, placeholder: 'The story of the child (optional)'
+              = f.input :description, label: false, placeholder: 'The description, e.g. Children playing in the garden, mountains in background'
             .form-group.text-center
               = f.input :subject_matter, collection: ["Home / Country of origin", "Transit", "Camp life", "Future hopes / destination"], label: false, required: true, prompt: "Subject matter of drawing"
             .form-group.text-center
@@ -30,6 +27,17 @@
               = f.input :mood_rating, type: 'number', required: true, label: false, placeholder: 'Mood rating (1 to 10)'
             .form-group.text-center
               = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: false, include_blank: "Country picture was drawn in", class: 'form-control'
+
+            %hr
+
+            .h4 Details of artist
+
+            .form-group.text-center
+              = f.input :age, type: 'number', label: false, required: true, placeholder: 'Age of artist'
+            .form-group.text-center
+              = f.input :gender, collection: ["Female", "Male"], label: false, required: true, prompt: "Gender of artist"
+            .form-group.text-center
+              = f.input :story, label: false, required: false, placeholder: 'Context / story of the artist, e.g. interesting cultural or psychological notes (optional)'
             .form-group.text-center
               %label_tag{for: "status"} Status (leave this as Pending if you need to enter required details later)
               = f.input :status, collection: radio_statuses, label_method: lambda {|k| k.last.capitalize }, as: :radio_buttons, required: true, label: false

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -2,10 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Drawing, type: :model do
   describe "validations" do
-    context "presence" do
-      %i(image age gender subject_matter mood_rating status).each do |attr|
-        it { is_expected.to validate_presence_of attr }
-      end
+    PRIORITY_FIELDS = %i(description subject_matter mood_rating country).freeze
+
+    subject { FactoryGirl.build(:drawing, attrs) }
+
+    let(:attrs) { FactoryGirl.attributes_for(:drawing, status: status) }
+    let(:status) { "complete" }
+
+    it { is_expected.to define_enum_for(:status).with(%i(pending complete)) }
+
+    %i(image status).each do |attr|
+      it { is_expected.to validate_presence_of attr }
     end
 
     it { is_expected.to validate_numericality_of(:age) }
@@ -20,6 +27,18 @@ RSpec.describe Drawing, type: :model do
         .is_less_than_or_equal_to(10)
     end
 
-    it { is_expected.to define_enum_for(:status).with(%i(pending complete)) }
+    context "status is complete" do
+      PRIORITY_FIELDS.each do |attr|
+        it { is_expected.to validate_presence_of attr }
+      end
+    end
+
+    context "status is pending" do
+      let(:status) { "pending" }
+
+      PRIORITY_FIELDS.each do |attr|
+        it { is_expected.to_not validate_presence_of attr }
+      end
+    end
   end
 end


### PR DESCRIPTION
**Addresses #49**
# What this does

Splits the drawing form fields / UI into two categories:
1) Fields that describe the drawing
2) Fields that describe the artist

When the status is flagged as `pending`, the only fields that are mandatory are `image` and `status`.

When the status is flagged as `complete`, all drawing-based fields (i.e. Description, Subject Matter, Mood Rating, Country Picture was Drawn In) are mandatory and validated.

Artist-based fields are always optional. 
# Screenshots

<img width="817" alt="screen shot 2016-08-07 at 22 03 50" src="https://cloud.githubusercontent.com/assets/574526/17465281/eac6560a-5cea-11e6-9ea7-22fcc0117364.png">
