### PR TITLE
Add thumb size to paperclip image styles

### DIFF
--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -14,7 +14,11 @@ class Drawing < ActiveRecord::Base
   validates :age, numericality: { only_integer: true }, allow_nil: true
   validates :mood_rating, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }, allow_nil: true
 
-  has_attached_file :image, styles: { medium: "640x" }
+  has_attached_file :image, styles: {
+    medium: "640x",
+    thumb: "100x100#"
+  }
+
   validates_attachment_content_type :image, content_type: %r{\Aimage\/.*\Z}
 
   belongs_to :user


### PR DESCRIPTION
# What this does

Adds a centre-cropped square thumbnail of 100x100 dimensions to Paperclip's image upload styles. This means we'll have a set of: original, medium, thumb.
## Dev notes

These sizes can be called with `drawing.image.url(:thumb)`.

To regenerate all images that aren't already existing locally, run the rake task:

`rake paperclip:refresh:missing_styles` (might have to prefix with `bundle exec`.

These will generate a thumb folder per image where your local images are stored, i.e. in `public/system/...` and in equivalent S3 folders on live.

Best read-up for more background here: https://github.com/thoughtbot/paperclip/wiki/Thumbnail-Generation
