### PR TITLE
[#75] Fix pagination issue, some link fixes and enable drawing edit/delete access to same organisation users

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -1,7 +1,7 @@
 class DrawingsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_drawing, only: [:show, :edit, :update, :destroy]
-  before_action :owned_drawing, only: [:edit, :update, :destroy]
+  before_action :check_access_to_drawing, only: [:edit, :update, :destroy]
 
   def index
     @drawings = (Drawing.desc.page params[:page]).decorate
@@ -55,9 +55,9 @@ class DrawingsController < ApplicationController
 
   private
 
-  def owned_drawing
-    return unless current_user != @drawing.user
-    flash[:alert] = "That's not your drawing."
+  def check_access_to_drawing
+    return if @drawing.viewer_can_change?(current_user)
+    flash[:alert] = "Only users from the same organisation can edit or delete drawings."
     redirect_to root_path
   end
 

--- a/app/decorators/drawing_decorator.rb
+++ b/app/decorators/drawing_decorator.rb
@@ -5,4 +5,18 @@ class DrawingDecorator < Draper::Decorator
   def self.collection_decorator_class
     PaginatingDecorator
   end
+
+  def description_concat
+    text_concat(object.description)
+  end
+
+  def story_concat
+    text_concat(object.story)
+  end
+
+  private
+
+  def text_concat(text, max_length = 30)
+    text[0, max_length-1].concat('...')
+  end
 end

--- a/app/decorators/drawing_decorator.rb
+++ b/app/decorators/drawing_decorator.rb
@@ -16,7 +16,7 @@ class DrawingDecorator < Draper::Decorator
 
   private
 
-  def text_concat(text, max_length = 30)
-    text[0, max_length-1].concat('...')
+  def text_concat(text, max_length=30)
+    text[0, max_length - 1].concat('...')
   end
 end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -25,4 +25,8 @@ class Drawing < ActiveRecord::Base
   belongs_to :user
 
   scope :desc, -> { order("drawings.created_at DESC") }
+
+  def viewer_can_change?(viewer)
+    viewer.organisation == user.organisation
+  end
 end

--- a/app/views/drawings/_drawing.html.haml
+++ b/app/views/drawings/_drawing.html.haml
@@ -19,6 +19,5 @@
             - if drawing.country.present?
               drawn in
               = ISO3166::Country.find_country_by_alpha2(drawing.country).name
-          - if drawing.pending?
-            .drawing-status-pending
-              = "Pending".upcase
+          .drawing-status-pending
+            = drawing.status.upcase

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -3,7 +3,8 @@
     %td
       = drawing.id
     %td
-      = image_tag drawing.image.url(:thumb)
+      = link_to drawing_path(drawing) do
+        = image_tag drawing.image.url(:thumb)
     %td
       = drawing.subject_matter
     %td
@@ -17,17 +18,15 @@
     %td
       = drawing.mood_rating
     %td
-      = link_to drawing_path(drawing) do
-        %i.fa.fa-pencil{"aria-hidden" => "true"}
+      - if drawing.viewer_can_change?(current_user)
+        = link_to edit_drawing_path(drawing) do
+          %i.fa.fa-pencil{"aria-hidden" => "true"}
     %td
-      = link_to drawing_path(drawing.id), method: :delete, data: { confirm: 'Are you sure?' } do
-        %i.fa.fa-trash{"aria-hidden" => "true"}
+      - if drawing.viewer_can_change?(current_user)
+        = link_to drawing_path(drawing.id), method: :delete, data: { confirm: 'Are you sure?' } do
+          %i.fa.fa-trash{"aria-hidden" => "true"}
     %td
       = drawing.user.email
     %td
-      - if drawing.pending?
-        .drawing-status-pending
-          = "Pending".upcase
-      - else
-        .drawing-status-pending
-          = "Completed".upcase
+      .drawing-status-pending
+        = drawing.status.upcase

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -1,51 +1,33 @@
-.container
-  %h3 Manage Drawings
-  %table.table.table-bordered.table-condensed.table-hover.table-responsive
-    %thead
-      %tr
-        %th ID
-        %th File
-        %th Subject Matter
-        %th Description
-        %th Artist's Age
-        %th Artist's Gender
-        %th Artist's Background
-        %th Mood Rate
-        %th Edit
-        %th Delete
-        %th User Admin
-        %th Status
-    %tbody
-    - @drawings.each do |drawing|
-      %tr
-        %td
-          = drawing.id
-        %td
-          = image_tag drawing.image.url(:thumb)
-        %td
-          = drawing.subject_matter
-        %td
-          = drawing.description[0, 29].concat('...')
-        %td
-          = drawing.age
-        %td
-          = drawing.gender.humanize
-        %td
-          = drawing.story
-        %td
-          = drawing.mood_rating
-        %td
-          = link_to drawing_path(drawing) do
-            %i.fa.fa-pencil{"aria-hidden" => "true"}
-        %td
-          = link_to drawing_path(drawing.id), method: :delete, data: { confirm: 'Are you sure?' } do
-            %i.fa.fa-trash{"aria-hidden" => "true"}
-        %td
-          = drawing.user.email
-        %td
-          - if drawing.pending?
-            .drawing-status-pending
-              = "Pending".upcase
-          - else
-            .drawing-status-pending
-              = "Completed".upcase
+- @drawings.each do |drawing|
+  %tr
+    %td
+      = drawing.id
+    %td
+      = image_tag drawing.image.url(:thumb)
+    %td
+      = drawing.subject_matter
+    %td
+      = drawing.description[0, 29].concat('...')
+    %td
+      = drawing.age
+    %td
+      = drawing.gender
+    %td
+      = drawing.story
+    %td
+      = drawing.mood_rating
+    %td
+      = link_to drawing_path(drawing) do
+        %i.fa.fa-pencil{"aria-hidden" => "true"}
+    %td
+      = link_to drawing_path(drawing.id), method: :delete, data: { confirm: 'Are you sure?' } do
+        %i.fa.fa-trash{"aria-hidden" => "true"}
+    %td
+      = drawing.user.email
+    %td
+      - if drawing.pending?
+        .drawing-status-pending
+          = "Pending".upcase
+      - else
+        .drawing-status-pending
+          = "Completed".upcase

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -8,13 +8,13 @@
     %td
       = drawing.subject_matter
     %td
-      = drawing.description[0, 29].concat('...')
+      = drawing.description_concat
     %td
       = drawing.age
     %td
       = drawing.gender
     %td
-      = drawing.story
+      = drawing.story_concat
     %td
       = drawing.mood_rating
     %td

--- a/app/views/drawings/edit.html.haml
+++ b/app/views/drawings/edit.html.haml
@@ -3,4 +3,4 @@
 .text-center.edit-links
   = link_to "Cancel", drawing_path(@drawing)
   |
-  = link_to "Delete Post", drawing_path(@drawing), method: :delete, data: { confirm: 'Are you sure?' }
+  = link_to "Delete Drawing", drawing_path(@drawing), method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/drawings/index.html.haml
+++ b/app/views/drawings/index.html.haml
@@ -14,7 +14,7 @@
           %th Mood Rate
           %th Edit
           %th Delete
-          %th User Admin
+          %th Added By User
           %th Status
       %tbody
         = render 'drawings'

--- a/app/views/drawings/index.html.haml
+++ b/app/views/drawings/index.html.haml
@@ -1,5 +1,23 @@
 #drawings
-  = render 'drawings'
+  .container
+    %h3 Manage Drawings
+    %table.table.table-bordered.table-condensed.table-hover.table-responsive
+      %thead
+        %tr
+          %th ID
+          %th File
+          %th Subject Matter
+          %th Description
+          %th Artist's Age
+          %th Artist's Gender
+          %th Artist's Background
+          %th Mood Rate
+          %th Edit
+          %th Delete
+          %th User Admin
+          %th Status
+      %tbody
+        = render 'drawings'
 
 #paginator.text-center
   = link_to_next_page @drawings, 'MORE', remote: true, id: 'load_more'

--- a/app/views/drawings/index.js.erb
+++ b/app/views/drawings/index.js.erb
@@ -1,3 +1,3 @@
-$('#drawings').append("<%= escape_javascript(render 'drawings') %>");
+$('#drawings .container table').append("<%= escape_javascript(render 'drawings') %>");
 $('#paginator').html("<%= escape_javascript(link_to_next_page(@drawings, 'MORE', remote: true, id: 'load_more')) %>");
 if (!$('#load_more').length) { $('#paginator').remove(); }

--- a/app/views/drawings/show.html.haml
+++ b/app/views/drawings/show.html.haml
@@ -1,6 +1,6 @@
 = render 'drawing', drawing: @drawing
 .text-center.edit-links
-  = link_to "Cancel", drawings_path
-  - if current_user == @drawing.user
+  = link_to "Back To List", drawings_path
+  - if @drawing.viewer_can_change?(current_user)
     |
     = link_to "Edit Drawing", edit_drawing_path(@drawing)

--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,5 +1,5 @@
 Kaminari.configure do |config|
-  config.default_per_page = 3
+  config.default_per_page = 10
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
Addresses #75 

:eyes: **Reviewers - some indentation changes so view without whitespace diff:** - https://github.com/empowerhack/DrawMyLife-Service/pull/77/files?w=1
# What this does

Fixes small pagination bug which was repeating the entire table instead of its X number of rows only. Also increases the max rows to 10 from 3.

**Also:**
- Change edit/delete access to drawings so any user from the same organisation can edit.
- Hide delete/edit icons if they can't delete/edit.
- Add link to View Post to thumbnail, and update Edit link to go to edit view.
- Simplify status logic.
- Some small copy changes.
## Screenshots (after clicking 'More')

**Before:**

<img width="1211" alt="screen shot 2016-08-14 at 22 10 46" src="https://cloud.githubusercontent.com/assets/574526/17652098/169f6e70-626c-11e6-877f-a67dd4aa3dd6.png">

**After:**

<img width="1173" alt="screen shot 2016-08-14 at 22 11 16" src="https://cloud.githubusercontent.com/assets/574526/17652103/298cda36-626c-11e6-8476-dfd90d0bc810.png">
