### PR TITLE
56 fix gender field

### DIFF
--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -19,6 +19,13 @@ module DrawingsHelper
     end
   end
 
+  def radio_genders
+    # Example output: [ ["gender0", "gender0"], ["gender1", "gender1"] ... ]
+    [].tap do |arr|
+      Drawing.genders.keys.each { |s| arr << [s, s] }
+    end
+  end
+
   def mood_select_box
     # Example output: [ ["1 (sad face)", 1], ["2", 2] ... ["9", 9] ["10 (happy face)", 10] ]
     selections = [].tap do |arr|

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -1,5 +1,6 @@
 class Drawing < ActiveRecord::Base
   enum status: %i(pending complete)
+  enum gender: %i(not_specified female male other)
 
   validates :image, presence: true
   validates :status, presence: true

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -29,7 +29,7 @@
         %td
           = drawing.age
         %td
-          = drawing.gender
+          = drawing.gender.humanize
         %td
           = drawing.story
         %td

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -28,9 +28,9 @@
             .h4 Details of artist
 
             .form-group.text-center
-              = f.input :age, type: 'number', label: false, required: true, placeholder: 'Age of artist'
+              = f.input :age, type: 'number', label: false, required: false, placeholder: 'Age of artist'
             .form-group.text-center
-              = f.input :gender, collection: ["Female", "Male"], label: false, required: true, prompt: "Gender of artist"
+              = f.input :gender, collection: radio_genders, label_method: lambda {|k| k.humanize }, as: :radio_buttons, required: false label: false
             .form-group.text-center
               = f.input :story, label: false, required: false, placeholder: 'Context / story of the artist, e.g. interesting cultural or psychological notes (optional)'
             .form-group.text-center

--- a/db/migrate/20160815092330_change_gender_type_in_drawings.rb
+++ b/db/migrate/20160815092330_change_gender_type_in_drawings.rb
@@ -1,0 +1,11 @@
+class ChangeGenderTypeInDrawings < ActiveRecord::Migration
+  def up
+    remove_column :drawings, :gender
+    add_column :drawings, :gender, :integer, default: 0
+  end
+
+  def down
+    remove_column :drawings, :gender
+    add_column :drawings, :gender, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160814222038) do
+ActiveRecord::Schema.define(version: 20160815092330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,11 +27,11 @@ ActiveRecord::Schema.define(version: 20160814222038) do
     t.integer  "user_id"
     t.integer  "mood_rating"
     t.integer  "age"
-    t.string   "gender"
     t.string   "subject_matter"
     t.text     "story"
     t.string   "country"
     t.integer  "status",             default: 0
+    t.integer  "gender",             default: 0
   end
 
   add_index "drawings", ["user_id"], name: "index_drawings_on_user_id", using: :btree

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Drawing, type: :model do
     let(:status) { "complete" }
 
     it { is_expected.to define_enum_for(:status).with(%i(pending complete)) }
+    it { is_expected.to define_enum_for(:gender).with(%i(not_specified female male other)) }
 
     %i(image status).each do |attr|
       it { is_expected.to validate_presence_of attr }


### PR DESCRIPTION
Makes gender an enum based off integer DB column

N.B. Makes no attempt to transfer existing gender values across to new DB column
- [x] Add gender enum to Drawing model
- [x] Change gender on drawing form to radio buttons
- [x] Pass correct values to form (and humanize labels)
- [x] Test

---

**Deploy instructions**

Will require `rake db:migrate` to be performed
