### PR TITLE
Only load hotjar on production environment

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,5 +14,5 @@
         = content_tag :div, msg, class: [:alert, alert_for(name)]
     = yield
 
-    = javascript_include_tag 'hotjar.js'
-    
+    - if Rails.env.production?
+      = javascript_include_tag 'hotjar.js'


### PR DESCRIPTION
HotJar loading in the development environment is causing videos of local testing to be uploaded

http://insights.hotjar.com/p?site=266587&recording=267931897

This PR stops this by only loading Hotjar if on the Rails production environment.
