### PR TITLE
Creates working gender radio buttons on drawing form

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -23,3 +23,24 @@
     text-align: center;
   }
 }
+
+/* THIS IS A HACK. PLEASE FIX! */
+.form-group.genders {
+  label {
+    border-radius: 5px;
+    padding-left: 15px;
+    margin-right: 5px;
+  }
+  label[for=drawing_gender_not_specified] {
+    background-color: #D3D3D3;
+  }
+  label[for=drawing_gender_female] {
+    background-color: #FFB6C1;
+  }
+  label[for=drawing_gender_male] {
+    background-color: #ADD8E6;
+  }
+  label[for=drawing_gender_other] {
+    background-color: #FFE8CD;
+  }
+}

--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -20,9 +20,9 @@ module DrawingsHelper
   end
 
   def radio_genders
-    # Example output: [ ["gender0", "gender0"], ["gender1", "gender1"] ... ]
+    # Example output: [ ["gender0", "Gender 0"], ["gender1", "Gender 1"] ... ]
     [].tap do |arr|
-      Drawing.genders.keys.each { |s| arr << [s, s] }
+      Drawing.genders.keys.each { |s| arr << [s, s.humanize] }
     end
   end
 

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -12,7 +12,7 @@
     %td
       = drawing.age
     %td
-      = drawing.gender
+      = drawing.gender.humanize
     %td
       = drawing.story_concat
     %td

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -14,16 +14,10 @@
         %h4 Details of Artist
         .form-group
           = f.input :age, type: 'number', label: false, required: true, placeholder: 'Age of artist'
-        .form-group
-          = f.label :gender, class: "btn" do
-            = f.radio_button :gender, "female"
-            Female
-          = f.label :gender, class: "btn btn-primary" do
-            = f.radio_button :gender, "male"
-            Male
-          = f.label :gender, class: "btn" do
-            = f.radio_button :gender, "other"
-            Other
+        .form-group.genders
+          = f.collection_radio_buttons :gender, radio_genders, :first, :last do |b|
+            = b.radio_button
+            = b.label(class: "btn")
         .form-group
           = f.input :story, label: false, required: false, placeholder: 'Context / story of the artist, e.g. interesting cultural or psychological notes (optional)'
           -# .form-group


### PR DESCRIPTION
Updates the new responsive form uploader with working gender selector. Also fixes the drawings table to show a humanized version of the gender

I've hacked together some basic CSS for them, but it is a real hack (you'll see!), so would expect @tanyapowell would want to refactor that!

![image](https://cloud.githubusercontent.com/assets/4599695/17831506/9fc62c32-66e2-11e6-94e2-56e63f919e6f.png)

![image](https://cloud.githubusercontent.com/assets/4599695/17831518/d686d136-66e2-11e6-9bf0-b5dfaaf1bcec.png)
