### PR TITLE
Allows pdfs to be uploaded and converted

### DIFF
--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -18,11 +18,11 @@ class Drawing < ActiveRecord::Base
   has_attached_file :image, styles: {
     medium: ["640x", :jpg],
     thumb: ["100x100#", :jpg],
-    original: ["100%", :jpg]
+    large: ["100%", :jpg]
   }
 
-  validates_attachment_content_type :image, content_type: %r{\Aimage\/(jpeg|png|gif|tiff|bmp)\z},
-                                            message: "Accepted image formats are: jpg/jpeg, png, tiff, gif, bmp"
+  validates_attachment_content_type :image, content_type: %r{\A(image\/(jpeg|png|gif|tiff|bmp)|application\/pdf)\z},
+                                            message: "Accepted image formats are: jpg/jpeg, png, tiff, gif, bmp, pdf"
 
   belongs_to :user
 

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Drawing, type: :model do
 
       it do
         is_expected.to validate_attachment_content_type(:image)
-          .allowing('image/png', 'image/gif', 'image/jpeg', 'image/tiff', 'image/bmp')
-          .rejecting('application/pdf', 'image/x-png')
+          .allowing('image/png', 'image/gif', 'image/jpeg', 'image/tiff', 'image/bmp', 'application/pdf')
+          .rejecting('application/zip', 'image/x-png')
       end
     end
 


### PR DESCRIPTION
This branch will allow PDFs to be uploaded. Fixes issue 

It has been necessary to change the `original` image format to `large`, as `original` actually edits the original, rather than making a copy called `original` which was expected. This image format is currently not used anywhere, so is not a problem currently.

However, if the large format is used in future, pictures uploaded before this change will fail to load the "large" format. I will look to fix this with a migration in the future.
- [x] Enable pdf upload
- [ ] Migration to create large format of all existing images
