### PR TITLE
Allows pdfs to be uploaded and converted

### DIFF
--- a/app/assets/javascripts/drawings.js.erb
+++ b/app/assets/javascripts/drawings.js.erb
@@ -2,7 +2,7 @@ var loadFile = function(event) {
   var output = document.getElementById('image-preview');
   var imgFile = event.target.files[0];
 
-  if (imgFile.type === "image/tiff") {
+  if (imgFile.type === "image/tiff" || imgFile.type === "application/pdf") {
     output.src = '<%= asset_path "placeholder-green.png" %>';
   } else {
     output.src = URL.createObjectURL(imgFile);


### PR DESCRIPTION
This branch will allow PDFs to be uploaded.

It has been necessary to change the original image format to large, as original actually edits the original, rather than making a copy called original which was expected. This image format is currently not used anywhere, so is not a problem currently.

However, if the large format is used in future, pictures uploaded before this change will fail to load the "large" format. I will look to fix this with a migration in the future.

 Enable pdf upload
 Migration to create large format of all existing images
