### PR TITLE
Allows pdfs to be uploaded and converted

### DIFF
--- a/app/assets/javascripts/drawings.js.erb
+++ b/app/assets/javascripts/drawings.js.erb
@@ -2,7 +2,7 @@ var loadFile = function(event) {
   var output = document.getElementById('image-preview');
   var imgFile = event.target.files[0];
 
-  if (imgFile.type === "image/tiff") {
+  if (imgFile.type === "image/tiff" || imgFile.type === "application/pdf") {
     output.src = '<%= asset_path "placeholder-green.png" %>';
   } else {
     output.src = URL.createObjectURL(imgFile);

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -19,6 +19,8 @@ class Drawing < ActiveRecord::Base
     medium: ["640x", :jpg],
     thumb: ["100x100#", :jpg],
     large: ["100%", :jpg]
+  }, convert_options: {
+    all: "-bordercolor none -border 1 -trim"
   }
 
   validates_attachment_content_type :image, content_type: %r{\A(image\/(jpeg|png|gif|tiff|bmp)|application\/pdf)\z},

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -18,11 +18,11 @@ class Drawing < ActiveRecord::Base
   has_attached_file :image, styles: {
     medium: ["640x", :jpg],
     thumb: ["100x100#", :jpg],
-    original: ["100%", :jpg]
+    large: ["100%", :jpg]
   }
 
-  validates_attachment_content_type :image, content_type: %r{\Aimage\/(jpeg|png|gif|tiff|bmp)\z},
-                                            message: "Accepted image formats are: jpg/jpeg, png, tiff, gif, bmp"
+  validates_attachment_content_type :image, content_type: %r{\A(image\/(jpeg|png|gif|tiff|bmp)|application\/pdf)\z},
+                                            message: "Accepted image formats are: jpg/jpeg, png, tiff, gif, bmp, pdf"
 
   belongs_to :user
 

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Drawing, type: :model do
 
       it do
         is_expected.to validate_attachment_content_type(:image)
-          .allowing('image/png', 'image/gif', 'image/jpeg', 'image/tiff', 'image/bmp')
-          .rejecting('application/pdf', 'image/x-png')
+          .allowing('image/png', 'image/gif', 'image/jpeg', 'image/tiff', 'image/bmp', 'application/pdf')
+          .rejecting('application/zip', 'image/x-png')
       end
     end
 


### PR DESCRIPTION
This branch will allow PDFs to be uploaded.

It has been necessary to change the original image format to large, as using `original` actually edits the original, rather than making a copy called original which was expected. This image format is currently not used anywhere, so is not a problem currently.

~~However, if the large format is used in future, pictures uploaded before this change will fail to load the "large" format. I will look to fix this with a migration in the future.~~

After this change, we can run `rake paperclip:refresh:missing_styles CLASS=Drawing`to update existing images to create any styles that are missing.

PDFs uploaded were being given black edges, replacing transparency which existed. To trim transparency only, we need to add a small transparent border, then trim. This will ensure pictures with a coloured edge do not get trimmed incorrectly, yet the transparent edges from PDFs _are_ trimmed.

---
- [x] Enable pdf upload
- [x] Migration to create large jpg format of all existing images - run `rake paperclip:refresh:missing_styles CLASS=Drawing`to update existing images
## Deploy Instructions
- run `rake paperclip:refresh:missing_styles CLASS=Drawing` to update existing images to give them a `large` version
