### PR TITLE
Increase text limit and only show elipses if text too long

### DIFF
--- a/app/decorators/drawing_decorator.rb
+++ b/app/decorators/drawing_decorator.rb
@@ -16,7 +16,7 @@ class DrawingDecorator < Draper::Decorator
 
   private
 
-  def text_concat(text, max_length=30)
-    text[0, max_length - 1].concat('...')
+  def text_concat(text, max_length=100)
+    text.length > max_length ? text[0, max_length - 1].concat('...') : text
   end
 end


### PR DESCRIPTION
Currently, we always add ellipses to the end of description and story on the index page, even if they haven't been trimmed.

This increases the limit to 100 characters, and will only add ellipses if the content has been trimmed
## Before

![image](https://cloud.githubusercontent.com/assets/4599695/18032789/6f3fbb6e-6d09-11e6-960a-6573a2d5f1ba.png)
## After

![image](https://cloud.githubusercontent.com/assets/4599695/18032796/92e7d3ee-6d09-11e6-8a8d-40bbfbf4def2.png)
