### PR TITLE
Temp CSV export functionality to sample some HDX data in HXL format.

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -4,12 +4,14 @@ class DrawingsController < ApplicationController
   before_action :check_access_to_drawing, only: [:edit, :update, :destroy]
 
   def index
-    @drawings = (Drawing.desc.page params[:page]).decorate
+    drawings = (Drawing.desc.page params[:page])
+    @drawings = drawings.decorate
 
     respond_to do |format|
       format.html
       format.js
       format.json { render json: @drawings }
+      format.csv { render text: drawings.to_csv(hxl: params[:hxl].present?) }
     end
   end
 

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -30,6 +30,21 @@ class Drawing < ActiveRecord::Base
 
   scope :desc, -> { order("drawings.created_at DESC") }
 
+  def self.to_csv(hxl: false)
+    fields = %w(org country age gender mood_rating description created_at)
+
+    CSV.generate do |csv|
+      csv << fields.map(&:capitalize)
+      csv << fields.map { |field| "#" + field } if hxl
+
+      # Only export completed entries
+      complete.each do |drawing|
+        values = drawing.attributes.values_at(*fields.drop(1))
+        csv << values.unshift(drawing.user.organisation.name)
+      end
+    end
+  end
+
   def viewer_can_change?(viewer)
     viewer.organisation == user.organisation
   end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -31,7 +31,7 @@ class Drawing < ActiveRecord::Base
   scope :desc, -> { order("drawings.created_at DESC") }
 
   def self.to_csv(hxl: false)
-    fields = %w(org country age gender mood_rating description created_at)
+    fields = %w(org country age gender mood_rating description story created_at)
 
     CSV.generate do |csv|
       csv << fields.map(&:capitalize)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../boot', __FILE__)
+require 'csv'
 require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
# What this does

Quick PR to temporarily enable CSV downloads of all drawing data by browsing to e.g. `/drawings.csv?hxl=true`. 
# Example Output

NB: if the `?hxl` param is present, the second line of hxl-formatted hashtags will be included.

```
Org,Country,Age,Gender,Mood_rating,Description,Created_at
#org,#country,#age,#gender,#mood_rating,#description,#created_at
Terre Des Hommes,GB,30,0,10,Bus and mountains,2016-09-03 17:17:31 UTC
Terre Des Hommes,GR,10,0,10,"Children and their families in the sea, playing, sunny",2016-08-07 15:44:43 UTC

```
