### PR TITLE
bootstrap meta tag added for mobile responsiveness

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta(name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no")
     %title DrawMyLifeService
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true


### PR DESCRIPTION
#### Addresses issue: #106
### **_BUG ALERT_** - Menu is no longer visible will open a new task to fix
## What this does

Makes use [Bootstrap's](http://getbootstrap.com/css/) **_Mobile First_** ideology, so all views should now be mobile responsive.
## Screenshots

Before
![image](https://cloud.githubusercontent.com/assets/11095605/19325538/809a1368-90be-11e6-95d2-ddc8a492b0fc.png)

After
![image](https://cloud.githubusercontent.com/assets/11095605/19325578/b80d716e-90be-11e6-9f0a-02b43b563bbc.png)
