### PR TITLE
navbar/menu now mobile responsive and sass tidy up

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,7 @@
 
 html, body {
   height: 100%;
-  background-color: $iceWhite;
+  background-color: $ice-white;
   font-family: proxima-nova, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 

--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -10,17 +10,16 @@
   }
 }
 
-.navbar-default {
+.navbar-toggle {
+  background-color: $ice-white;
+}
+
+.navbar-default, .navbar-collapse {
   background-color: $dark-grey;
-  height: $navbar-height;
   @include border-radius(0);
   border: none;
 
   .navbar-nav li {
-    &.separator>a {
-      border-right: 2px solid $white;
-    }
-
     a {
       color: $white;
 
@@ -48,4 +47,10 @@
       }
     }
   }
+}
+
+@media (max-width: 767px) {
+  .navbar-collapse .navbar-nav .open .dropdown-menu > li > a {
+      color: $ice-white;
+    }
 }

--- a/app/assets/stylesheets/drawing-management.scss
+++ b/app/assets/stylesheets/drawing-management.scss
@@ -1,5 +1,5 @@
 @import "variables";
 
 thead {
-  background: $midGray;
+  background: $mid-gray;
 }

--- a/app/assets/stylesheets/drawings.scss
+++ b/app/assets/stylesheets/drawings.scss
@@ -12,7 +12,7 @@
 
 .drawing {
   background-color: $white;
-  border-color: $lightGray;
+  border-color: $light-gray;
   border-style: solid;
   border-radius: 3px;
   border-width: 1px;
@@ -23,7 +23,7 @@
     padding-left: $drawingsPadding;
     padding-right: $drawingsPadding;
     padding-top: $drawingsPadding;
-    color: $chathamsBlue;
+    color: $chathams-blue;
     font-size: 15px;
     line-height: 18px;
     .user-name, .time-ago {
@@ -41,8 +41,8 @@
     position: relative;
     overflow: hidden;
     padding-bottom: 100%;
-    border-bottom: 1px solid $lightGray;
-    border-top: 1px solid $lightGray;
+    border-bottom: 1px solid $light-gray;
+    border-top: 1px solid $light-gray;
   }
   .image img{
     position: absolute;
@@ -80,7 +80,7 @@
   .user-name {
     font-weight: 500;
     margin-right: 0.3em;
-    color: $chathamsBlue;
+    color: $chathams-blue;
     font-size: 15px;
   }
 

--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -5,7 +5,7 @@
   margin: 20px auto;
   background-color: $white;
   padding: 40px;
-  border: 1px solid $lightGray;
+  border: 1px solid $light-gray;
   border-radius: 3px;
 }
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -2,16 +2,16 @@
 /**** Colours ****/
 $aluminium: #a5a7aa;
 $aubergine: #85144B;
-$chathamsBlue: #125688;
+$chathams-blue: #125688;
 $rose: #cb6264;
 
 // Greys
-$lightGray: #edeeee;
-$midGray: #ccc;
+$light-gray: #edeeee;
+$mid-gray: #ccc;
 $dark-grey: #232323;
 
 // Whites
-$iceWhite: #fafafa;
+$ice-white: #fafafa;
 $white: #fff;
 
 /***************************/
@@ -19,9 +19,4 @@ $white: #fff;
 /***************************/
 /**** Dimensions ****/
 $drawingsPadding: 24px;
-/***************************/
-
-/***************************/
-/**** Sizes ****/
-$navbar-height: 50px;
 /***************************/

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -1,16 +1,18 @@
-%nav.navbar.navbar-default
-  .navbar-container
-    .navbar-header
-      .navbar-brand= link_to "Draw My Life", root_path
-    #bs-example-navbar-collapse-1.collapse.navbar-collapse
+.navbar.navbar-default.navbar-static-top
+  .container
+    %button.navbar-toggle(type="button" data-toggle="collapse" data-target=".navbar-responsive-collapse")
+      %span.icon-bar
+      %span.icon-bar
+      %span.icon-bar
+    .navbar-brand= link_to "Draw My Life", root_path
+    .navbar-collapse.collapse.navbar-responsive-collapse
       %ul.nav.navbar-nav.navbar-right
         - if user_signed_in?
-          %li.divider{:role => "separator"}
-          %li.separator
-            = link_to root_path do 
+          %li
+            = link_to root_path do
               %i.fa.fa-home{"aria-hidden" => "true"}
               Manage Drawings
-          %li.separator
+          %li
             = link_to new_drawing_path do
               %i.fa.fa-plus{"aria-hidden" => "true"}
               Upload


### PR DESCRIPTION
#### Addresses issue: #120
## What this does
- A user no longer has to horizontally scroll on their phone to see all the items in the navbar when on a mobile device
- Variable names in sass files tidied up to follow the correct convention 
## Screenshots
### Before - _have to scroll to the right to see the whole navbar_

![image](https://cloud.githubusercontent.com/assets/11095605/19327696/2897f07c-90c8-11e6-9ab8-2ba7b7ea6ae3.png)
### After

![image](https://cloud.githubusercontent.com/assets/11095605/19327649/e0877fd2-90c7-11e6-9cc2-557b366516cf.png)
