### PR TITLE
#123 - Adds image consent field to drawings

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -47,3 +47,9 @@
     padding-left: 15px;
   }
 }
+
+.form-consent {
+  label {
+    font-weight: bold;
+  }
+}

--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -16,7 +16,7 @@ class DrawingsController < ApplicationController
   end
 
   def new
-    @drawing = current_user.drawings.build
+    @drawing = current_user.drawings.build.decorate
   end
 
   def create
@@ -64,7 +64,8 @@ class DrawingsController < ApplicationController
   end
 
   def drawing_params
-    params.require(:drawing).permit(:image, :description, :gender, :age, :mood_rating, :subject_matter, :story, :stage_of_journey, :country, :status)
+    params.require(:drawing).permit(:image, :description, :gender, :age, :mood_rating, :subject_matter,
+                                    :story, :stage_of_journey, :country, :status, :image_consent)
   end
 
   def set_drawing

--- a/app/decorators/drawing_decorator.rb
+++ b/app/decorators/drawing_decorator.rb
@@ -14,6 +14,10 @@ class DrawingDecorator < Draper::Decorator
     text_concat(object.story) unless object.story.nil?
   end
 
+  def image_consent_text
+    "Consent given by artist to share image on open source data platforms as deemed appropriate"
+  end
+
   private
 
   def text_concat(text, max_length=100)

--- a/app/helpers/drawings_helper.rb
+++ b/app/helpers/drawings_helper.rb
@@ -39,4 +39,8 @@ module DrawingsHelper
     selections[-1][0] += " 😃"
     selections
   end
+
+  def image_consent_default
+    @drawing.new_record? ? true : @drawing.image_consent
+  end
 end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -4,6 +4,7 @@ class Drawing < ActiveRecord::Base
 
   validates :image, presence: true
   validates :status, presence: true
+  validates_inclusion_of :image_consent, in: [true, false]
 
   with_options if: :complete? do |complete|
     complete.validates :description, presence: true

--- a/app/views/drawings/_drawing.html.haml
+++ b/app/views/drawings/_drawing.html.haml
@@ -55,4 +55,11 @@
             .drawing-row
               %strong Context / Story:
               = drawing.story
-            
+            %br
+            .drawing-row
+              - if drawing.image_consent
+                %span.fa.fa-check
+              - else
+                %span.fa.fa-times
+              %em
+                = drawing.image_consent_text

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -11,6 +11,8 @@
           %br
           %b Allowed image types: jpg/jpeg, png, tiff, gif, bmp
           = f.input :image, label: false, required: false, input_html: { onChange: 'loadFile(event)' }
+        .form-group.form-consent
+          = f.input :image_consent, label: @drawing.image_consent_text, input_html: { checked: image_consent_default }
 
       .col-md-7.col-sm-12.col-xs-12
         %h4 Details of Drawing (required when marked complete)

--- a/db/migrate/20161027201605_add_stage_of_journey_to_drawing.rb
+++ b/db/migrate/20161027201605_add_stage_of_journey_to_drawing.rb
@@ -1,5 +1,5 @@
 class AddStageOfJourneyToDrawing < ActiveRecord::Migration
   def change
-  	add_column :drawings, :stage_of_journey, :string
+    add_column :drawings, :stage_of_journey, :string
   end
 end

--- a/db/migrate/20161102222517_add_consent_to_drawings.rb
+++ b/db/migrate/20161102222517_add_consent_to_drawings.rb
@@ -1,0 +1,5 @@
+class AddConsentToDrawings < ActiveRecord::Migration
+  def change
+    add_column :drawings, :image_consent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160815092330) do
+ActiveRecord::Schema.define(version: 20161102222517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "drawings", force: :cascade do |t|
     t.string   "description"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "image_file_name"
     t.string   "image_content_type"
     t.integer  "image_file_size"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 20160815092330) do
     t.string   "country"
     t.integer  "status",             default: 0
     t.integer  "gender",             default: 0
+    t.string   "stage_of_journey"
+    t.boolean  "image_consent",      default: false, null: false
   end
 
   add_index "drawings", ["user_id"], name: "index_drawings_on_user_id", using: :btree

--- a/spec/factories/drawings.rb
+++ b/spec/factories/drawings.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     story "Context of the drawing, e.g. child's back story, cultural notes"
     country "GR"
     status "complete"
+    image_consent true
 
     user
   end

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Drawing, type: :model do
       end
     end
 
+    it { should_not allow_value(nil).for(:image_consent) }
+
     context "status is complete" do
       PRIORITY_FIELDS.each do |attr|
         it { is_expected.to validate_presence_of attr }


### PR DESCRIPTION
#### Addresses issues: #123 and #83 

## What this does
- [x] Adds `image_consent` field to Drawings
    - Must be true or false before drawing can be saved
    - Existing images will have an “unknown” status until they are edited, at which point, the checkbox will be ticked (obviously can be unticked), at which point they will no longer have an “unknown” state
    - For new images, the checkbox will be ticked by default (obviously can be unticked)
    - Wording based on previous tickets:
      - **"Consent given by artist to share image on open source data platforms as deemed appropriate"**
- [x] Adds front-end form element to Drawings form view to collect data.
- [x] Adds front-end element to Drawing show view to show data.
- [ ] Front end love
    - [ ] Confirm wording on form, validation messages, and drawing show view
    - [x] Bolden the text on form elements?
    - [ ] Re-jig where the form elements are?

## What this needs
1. Reviews
2. Someone to pick up the front-end tasks, make it a bit more pleasant to the eye

## Screenshots
### Before
![image](https://cloud.githubusercontent.com/assets/4599695/19988953/2b08b44a-a21b-11e6-8611-d5b55770c17a.png)
![image](https://cloud.githubusercontent.com/assets/4599695/19988965/4680e080-a21b-11e6-8dc4-f9bb1d1cd5f3.png)

### After
![image](https://cloud.githubusercontent.com/assets/4599695/20247068/143d3e4a-a9bc-11e6-91d2-37fb8d6438e4.png)
![image](https://cloud.githubusercontent.com/assets/4599695/20247074/31a9fafe-a9bc-11e6-8a0b-71d0c059e813.png)
