### PR TITLE
#136: Adds pathname to GA call to record page being viewed

### DIFF
--- a/app/assets/javascripts/google-analytics.js
+++ b/app/assets/javascripts/google-analytics.js
@@ -4,4 +4,4 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-84354173-1', 'auto');
-  ga('send', 'pageview');
+  ga('send', 'pageview', location.pathname);


### PR DESCRIPTION
#### Addresses issue: #136 

## What this does
- [x] Adds `location.pathname` to the google analytics call in order to gather analytics on the users journey through the app.

Turns out the fix was a lot simpler than I thought!

## Screenshots
Before
![image](https://cloud.githubusercontent.com/assets/4599695/21145891/c38ba2f4-c147-11e6-90ef-fd968fe60d0f.png)

After
![image](https://cloud.githubusercontent.com/assets/4599695/21145911/d3324f78-c147-11e6-83fb-677dde6f2429.png)


