### PR TITLE
Login style - extends same style to some more login pages

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -3,13 +3,13 @@
 @import "variables";
 
 .login-bg {
-  padding-top: 4em;
-  height: 100%;
-  background-image: image-url('loginbackg.jpg');
-  -moz-background-size: cover;
+  padding: 2em 0;
+  background: image-url('loginbackg.jpg') no-repeat center center fixed;
   -webkit-background-size: cover;
+  -moz-background-size: cover;
   -o-background-size: cover;
   background-size: cover;
+  min-height: 100vh;
 }
 
 .log-in {

--- a/app/views/layouts/_logged_out.html.haml
+++ b/app/views/layouts/_logged_out.html.haml
@@ -1,0 +1,12 @@
+.login-bg
+  .container
+    .row
+      .col-md-4.col-md-offset-4
+        .log-in.panel
+          .panel-heading
+            %h2
+              = heading
+          .panel-body
+            = yield
+        - if links
+          = render "profiles/shared/links"

--- a/app/views/profiles/confirmations/new.html.haml
+++ b/app/views/profiles/confirmations/new.html.haml
@@ -1,11 +1,8 @@
-.container
-  .row
-    %h2 Resend confirmation instructions
-    = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-      = f.error_notification
-      = f.full_error :confirmation_token
-      .form-inputs
-        = f.input :email, required: true, autofocus: true, input_html: { value: params[:email] }
-      .form-actions
-        = f.button :submit, "Resend confirmation instructions"
-    = render "profiles/shared/links"
+= render layout: 'layouts/logged_out', locals: { heading: "Resend confirmation instructions", links: true } do
+  = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    = f.full_error :confirmation_token
+    .form-inputs
+      = f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email', input_html: { value: params[:email], class: 'input-lg' }
+    .form-actions
+      = f.button :submit, "Resend instructions", class: 'btn-lg btn-primary btn-block'

--- a/app/views/profiles/confirmations/show.html.haml
+++ b/app/views/profiles/confirmations/show.html.haml
@@ -1,19 +1,15 @@
-.container
-  %h2 Account Activation
-
-  .row
-    = simple_form_for(resource, as: resource_name, url: update_user_confirmation_path, html: { method: :patch }, id: 'activation-form') do |f|
-      = f.error_notification
+= render layout: 'layouts/logged_out', locals: { heading: "Account Activation", links: false } do
+  = simple_form_for(resource, as: resource_name, url: update_user_confirmation_path, html: { method: :patch }, id: 'activation-form') do |f|
+    = f.error_notification
+    .form-group
+      .alert.alert-notice Please enter your new password to activate your account.
+      - if resource.try(:user_name)
+        for
+        = resource.user_name
+    - if @requires_password
       .form-group
-        .alert.alert-notice Please enter your new password to activate your account.
-        - if resource.try(:user_name)
-          for
-          = resource.user_name
-      - if @requires_password
-        .form-group
-          = f.input :password, autocomplete: "off", label: "Password", required: true
-          = f.input :password_confirmation, autocomplete: "off", label: "Password Confirmation", required: true
-
-        .form-group
-          = f.input :confirmation_token, as: :hidden
-          = f.submit "Activate", class: 'btn-lg btn-primary btn-block'
+        = f.input :password, autocomplete: "off", label: "Password", required: true, input_html: { class: 'input-lg' }
+        = f.input :password_confirmation, autocomplete: "off", label: "Password Confirmation", required: true, input_html: { class: 'input-lg' }
+      .form-group
+        = f.input :confirmation_token, as: :hidden
+        = f.submit "Activate", class: 'btn-lg btn-primary btn-block'

--- a/app/views/profiles/passwords/edit.html.haml
+++ b/app/views/profiles/passwords/edit.html.haml
@@ -1,15 +1,10 @@
-.container
-
-  %h2 Change your password
-
-  .row
-    = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-      = f.error_notification
-      = f.input :reset_password_token, as: :hidden
-      = f.full_error :reset_password_token
-      .form-inputs
-        = f.input :password, label: "New password", required: true, autofocus: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
-        = f.input :password_confirmation, label: "Confirm your new password", required: true
-      .form-actions
-        = f.button :submit, "Change my password"
-    = render "profiles/shared/links"
+= render layout: 'layouts/logged_out', locals: { heading: "Change your password", links: true } do
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+    = f.error_notification
+    = f.input :reset_password_token, as: :hidden
+    = f.full_error :reset_password_token
+    .form-inputs
+      = f.input :password, label: "New password", required: true, autofocus: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), input_html: { class: 'input-lg' }
+      = f.input :password_confirmation, label: "Confirm your new password", required: true, input_html: { class: 'input-lg' }
+    .form-actions
+      = f.button :submit, "Change my password", class: 'btn-lg btn-primary btn-block'

--- a/app/views/profiles/passwords/new.html.haml
+++ b/app/views/profiles/passwords/new.html.haml
@@ -1,12 +1,7 @@
-.container
-
-  %h2 Forgot your password?
-
-  .row
-    = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-      = f.error_notification
-      .form-inputs
-        = f.input :email, required: true, autofocus: true
-      .form-actions
-        = f.button :submit, "Send me reset password instructions"
-    = render "profiles/shared/links"
+= render layout: 'layouts/logged_out', locals: { heading: "Forgot your password?", links: true } do
+  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    .form-inputs
+      = f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email', input_html: { class: 'input-lg' }
+    .form-actions
+      = f.button :submit, "Reset my password", class: 'btn-lg btn-primary btn-block'

--- a/app/views/profiles/registrations/edit.html.haml
+++ b/app/views/profiles/registrations/edit.html.haml
@@ -10,24 +10,24 @@
             = simple_form_for(resource, as: resource_name, url: user_registration_path, html: { method: :put }) do |f|
               = f.error_notification
               .form-inputs
-                = f.input :email, autofocus: true, label: "Email"
+                = f.input :email, autofocus: true, label: "Email", input_html: { class: 'input-lg' }
                 - if devise_mapping.confirmable? && resource.pending_reconfirmation?
                   %div
                     Currently waiting confirmation for: #{resource.unconfirmed_email}
-                = f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false, label: "New Password"
-                = f.input :password_confirmation, required: false, label: "New Password Confirmation"
+                = f.input :password, autocomplete: "off", hint: "leave it blank if you don't want to change it", required: false, label: "New Password", input_html: { class: 'input-lg' }
+                = f.input :password_confirmation, required: false, label: "New Password Confirmation", input_html: { class: 'input-lg' }
                 .form-group
-                  = f.input :country, priority: TOP_COUNTRIES, include_blank: "Select a country", label: "Current Location", required: true, class: 'form-control'
+                  = f.input :country, priority: TOP_COUNTRIES, include_blank: "Select a country", label: "Current Location", required: true, class: 'form-control', input_html: { class: 'input-lg' }
                 .form-group
                   - if current_user.super_admin?
-                    = f.input :organisation_id, as: :select, collection: Organisation.all, include_blank: "Select an organisation (optional)", label: "Organisation"
+                    = f.input :organisation_id, as: :select, collection: Organisation.all, include_blank: "Select an organisation (optional)", label: "Organisation", input_html: { class: 'input-lg' }
                   - else
                     %strong Organisation
                     %br
                     = resource.decorate.organisation_link
                     %br
                     %em (NB: only super admins can change this)
-                = f.input :current_password, hint: "we need your current password to confirm your changes", required: true, label: "Current Password"
+                = f.input :current_password, hint: "we need your current password to confirm your changes", required: true, label: "Current Password", input_html: { class: 'input-lg' }
               .form-actions
                 = f.submit "Update", class: 'btn-lg btn-primary btn-block'
         %h3 Deactivate my account

--- a/app/views/profiles/sessions/new.html.haml
+++ b/app/views/profiles/sessions/new.html.haml
@@ -1,17 +1,9 @@
-.login-bg
-  .container
-    .row
-      .col-md-4.col-md-offset-4
-        .log-in.panel
-          .panel-heading
-            %h2 Log in
-          .panel-body
-            = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-              = f.error_notification
-              .form-inputs
-                = f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email', input_html: { class: 'input-lg' }
-                = f.input :password, required: true, autofocus: true, label: false, placeholder: 'Password', input_html: { class: 'input-lg' }
-                = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
-              .form-actions
-                = f.button :submit, "Log in", class: 'btn-lg btn-primary btn-block'
-        = render "profiles/shared/links"
+= render layout: 'layouts/logged_out', locals: { heading: "Log in", links: true } do
+  = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+    = f.error_notification
+    .form-inputs
+      = f.input :email, required: true, autofocus: true, label: false, placeholder: 'Email', input_html: { class: 'input-lg' }
+      = f.input :password, required: true, autofocus: true, label: false, placeholder: 'Password', input_html: { class: 'input-lg' }
+      = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+    .form-actions
+      = f.button :submit, "Log in", class: 'btn-lg btn-primary btn-block'

--- a/app/views/profiles/unlocks/new.html.haml
+++ b/app/views/profiles/unlocks/new.html.haml
@@ -1,9 +1,8 @@
-%h2 Resend unlock instructions
-= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
-  = f.error_notification
-  = f.full_error :unlock_token
-  .form-inputs
-    = f.input :email, required: true, autofocus: true
-  .form-actions
-    = f.button :submit, "Resend unlock instructions"
-= render "profiles/shared/links"
+= render layout: 'layouts/logged_out', locals: { heading: "Resend unlock instructions", links: true } do
+  = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+    = f.error_notification
+    = f.full_error :unlock_token
+    .form-inputs
+      = f.input :email, required: true, autofocus: true, input_html: { class: 'input-lg' }
+    .form-actions
+      = f.button :submit, "Resend unlock instructions", class: 'btn-lg btn-primary btn-block'


### PR DESCRIPTION
## What this does
- [x] Applies login-page styles to all non-logged in pages
- [x] Updates login background picture styling to cope with long pages
  - Using technique found here: https://css-tricks.com/perfect-full-page-background-image/#article-header-id-0
- [x] Refactored solution to take advantage of a shared layout

## Screenshots
### Forgotten Password page

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570613/85c0e396-cebf-11e6-975e-122735d502e5.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681496/51131bbe-d347-11e6-8011-265d42061aae.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681327/bbbe9174-d346-11e6-96d5-0669a3c708c8.png)|

### Resend Confirmation page

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570632/b75064cc-cebf-11e6-8240-1512dec51e47.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681525/784ad3f2-d347-11e6-8c51-9541076b56c7.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681337/c75c037c-d346-11e6-84a9-4ae1dd120ebf.png)|

### Account Activation page

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570663/17a56ea8-cec0-11e6-9a23-6fe4991c76c2.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21570737/dc93e4ec-cec0-11e6-98ce-5146e52c7597.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681219/365ac796-d346-11e6-82b3-ee1463be278b.png)|

### Change Password page

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570680/483af15a-cec0-11e6-8fd8-108fd04c6b46.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21570731/c9990458-cec0-11e6-9fa9-548659fbfcb7.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681379/dd7f10e0-d346-11e6-9996-6692e9778dca.png)|

### Edit Profile page
Changed styling on form elements to match larger styles on other forms

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570650/eb6383c0-cebf-11e6-8498-411f1b118182.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21570722/b269e838-cec0-11e6-96be-13a48438cad5.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681442/18ace35e-d347-11e6-92ea-56fa8cfba048.png)|

### Fix background image styling

| Before | After | Mobile (iPhone 6) |
|--------|------|--------|
|![image](https://cloud.githubusercontent.com/assets/4599695/21570700/7a74cc2c-cec0-11e6-8039-f9b4155e7289.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21570709/9915192a-cec0-11e6-8912-9aaa2786f1b0.png)|![image](https://cloud.githubusercontent.com/assets/4599695/21681419/0bb9aa42-d347-11e6-89d1-11c67b1b304a.png)|
