### PR TITLE
Adds Artist’s Country of Origin field to Drawings

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -68,7 +68,7 @@ class DrawingsController < ApplicationController
 
   def drawing_params
     params.require(:drawing).permit(:image, :description, :gender, :age, :mood_rating, :subject_matter,
-                                    :story, :stage_of_journey, :country, :status, :image_consent)
+                                    :story, :stage_of_journey, :country, :status, :image_consent, :origin_country)
   end
 
   def set_drawing

--- a/app/views/drawings/_drawing.html.haml
+++ b/app/views/drawings/_drawing.html.haml
@@ -30,10 +30,7 @@
             %h3 Details of Drawing
             .drawing-row
               %strong Country Drawn In:
-              - if drawing.country.present?
-                = ISO3166::Country.find_country_by_alpha2(drawing.country).name
-              - else
-                n/a
+              = ISO3166::Country.find_country_by_alpha2(drawing.country).name if drawing.country.present?
             .drawing-row
               %strong Subject Matter:
               = drawing.subject_matter
@@ -49,6 +46,9 @@
             .drawing-row
               %strong Gender:
               = drawing.gender.humanize
+            .drawing-row
+              %strong Country of Origin:
+              = ISO3166::Country.find_country_by_alpha2(drawing.origin_country).name if drawing.origin_country.present?
             .drawing-row
               %strong Stage of Journey:
               = drawing.stage_of_journey

--- a/app/views/drawings/_form.html.haml
+++ b/app/views/drawings/_form.html.haml
@@ -17,13 +17,13 @@
       .col-md-7.col-sm-12.col-xs-12
         %h4 Details of Drawing (required when marked complete)
         .form-group
-          = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: "Country drawn in", include_blank: "Country picture was drawn in", class: 'form-control'
+          = f.input :country, priority: TOP_COUNTRIES, selected: (@drawing.new_record? ? current_user.country : @drawing.country), label: "Country drawn in", include_blank: "-- select country that picture was drawn in --", class: 'form-control'
         .form-group
-          = f.input :subject_matter, collection: ["Home / Country of origin", "Transit", "Camp life", "Future hopes / destination"], label: 'Subject matter of drawing', required: false, prompt: "--select an option--"
+          = f.input :subject_matter, collection: ["Home / Country of origin", "Transit", "Camp life", "Future hopes / destination"], label: 'Subject matter of drawing', required: false, prompt: "-- select an option --"
         .form-group
           = f.input :description, label: 'Description of drawing', placeholder: 'e.g. Children playing in the garden, mountains in background'
         .form-group
-          = f.input :mood_rating, as: :select, collection: mood_select_box, label: 'How would you rate the mood of the drawing?', prompt: "Scale is from 1 (sad/tragic) to 5 (happy/joyful)"
+          = f.input :mood_rating, as: :select, collection: mood_select_box, label: 'How would you rate the mood of the drawing?', prompt: "-- scale is from 1 (sad/tragic) to 5 (happy/joyful) --"
 
         %hr
 
@@ -37,7 +37,9 @@
             = b.radio_button
             = b.label(class: "btn")
         .form-group
-          = f.input :stage_of_journey, collection: ["At home", "In temporary shelter", "Awaiting transit", "On the move", "Arrived at destination"], label: 'Stage of journey', required: false, prompt: "--select an option--"
+          = f.input :origin_country, priority: TOP_ORIGIN_COUNTRIES, selected: @drawing.origin_country, label: "Country of origin", include_blank: "-- select country that artist comes from --", class: 'form-control'
+        .form-group
+          = f.input :stage_of_journey, collection: ["At home", "In temporary shelter", "Awaiting transit", "On the move", "Arrived at destination"], label: 'Stage of journey', required: false, prompt: "-- select an option --"
         .form-group
           = f.input :story, label: 'Context / story of the artist', required: false, placeholder: 'e.g. interesting cultural or psychological notes (optional)'
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,1 +1,2 @@
 TOP_COUNTRIES = %w(GR HU RS).freeze
+TOP_ORIGIN_COUNTRIES = %w(AF IQ SY).freeze

--- a/db/migrate/20170303152046_add_origin_country_to_drawings.rb
+++ b/db/migrate/20170303152046_add_origin_country_to_drawings.rb
@@ -1,0 +1,5 @@
+class AddOriginCountryToDrawings < ActiveRecord::Migration
+  def change
+    add_column :drawings, :origin_country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102222517) do
+ActiveRecord::Schema.define(version: 20170303152046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20161102222517) do
     t.integer  "gender",             default: 0
     t.string   "stage_of_journey"
     t.boolean  "image_consent",      default: false, null: false
+    t.string   "origin_country"
   end
 
   add_index "drawings", ["user_id"], name: "index_drawings_on_user_id", using: :btree

--- a/spec/factories/drawings.rb
+++ b/spec/factories/drawings.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
     country "GR"
     status "complete"
     image_consent true
+    origin_country "SY"
 
     user
   end


### PR DESCRIPTION
- Adds Country of Origin field
- Removes inconsistency in drawing show view
- Removes inconsistencies in select box default values on drawing edit view

#### Addresses issue: #141 

## What this does
- [x] Adds Country of Origin
  - Gives priority in dropdown to Afghanistan, Iraq, and Syria in same way as Country drawn in give priority to Greece, Serbia, and Hungary
- [x] Removes inconsistency in drawing show view
  - Drawing show view will not show "n/a" for countries if not selected to keep in line with other fields
- [x] Removes inconsistencies in select box default values on drawing edit view
  - All select boxes on the drawing edit view now use `-- select this thing --` to show an action is required

## Deploy Instructions
- Will require `bundle exec rake db:migrate` to update the database with the new field
- Will require server restart to initialise the new constant `TOP_ORIGIN_COUNTRIES`

## Discussion points
1. We now have in our Drawing model a "country" to show country drawn in, and "origin_country" to show origin of artist - do we need to improve the clarity of this wording?
2. Any other countries we should be giving priority to on the dropdown for this new field?
3. In defiance of #141, I added the field under "Gender" instead of under "Age", as I feel Age and Gender are too closely related to be separated on the forms

## Screenshots
![image](https://cloud.githubusercontent.com/assets/4599695/23559250/3f80efb6-002e-11e7-9efd-80fe6676d6d8.png)
-----
![image](https://cloud.githubusercontent.com/assets/4599695/23558979/8b5af716-002d-11e7-9bcb-c715a2398d36.png)
