### PR TITLE
Adds decorate to drawing#create controller to fix bug

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -23,7 +23,7 @@ class DrawingsController < ApplicationController
   end
 
   def create
-    @drawing = current_user.drawings.build(drawing_params)
+    @drawing = current_user.drawings.build(drawing_params).decorate
     if @drawing.save
       flash[:success] = "Your drawing is uploaded."
       redirect_to drawings_path


### PR DESCRIPTION
#### Addresses issue: Bug when save of new drawing fails

How to replicate:
1. Go to Upload new drawing
2. Do not choose an image
3. Save
4. You are shown an error message:
![image](https://cloud.githubusercontent.com/assets/4599695/23592497/d2b8afd6-01f9-11e7-94ac-b206f045291b.png)

## What this does
- [x] Adds call to the decorate method when assigning `@drawing` on the Drawing#create method

## Screenshots
## Before
![image](https://cloud.githubusercontent.com/assets/4599695/23592497/d2b8afd6-01f9-11e7-94ac-b206f045291b.png)
## After
![image](https://cloud.githubusercontent.com/assets/4599695/23592534/6556dcd2-01fa-11e7-92bc-f39c02cbeda5.png)