### PR TITLE
[#149] Restrict access to drawings and organisations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def authorize_super_admin!
+    unless current_user.super_admin?
+      flash[:error] = "Sorry, you may be a super human being, but you need to be a super admin to do that."
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  private
+
   def authorize_super_admin!
     unless current_user.super_admin?
       flash[:error] = "Sorry, you may be a super human being, but you need to be a super admin to do that."

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,5 +1,5 @@
 class OrganisationsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, :authorize_super_admin!
   before_action :find_organisation, only: [:edit, :show, :update, :destroy]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, :authorize_user, :set_devise_mapping
+  before_action :authenticate_user!, :authorize_super_admin!, :set_devise_mapping
   before_action :set_user, only: [:show, :edit, :update, :destroy, :deactivate, :reactivate]
 
   def index
@@ -71,13 +71,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def authorize_user
-    unless current_user.super_admin?
-      flash[:error] = "Sorry, you may be a super human being, but you need to be a super admin to do that."
-      redirect_to root_path
-    end
-  end
 
   def user_params
     params.require(:user).permit(:email, :role, :country, :organisation_id)

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -30,6 +30,9 @@ class Drawing < ActiveRecord::Base
   belongs_to :user
 
   scope :desc, -> { order("drawings.created_at DESC") }
+  scope :within_org, lambda { |org_id|
+    joins(:user).where("users.organisation_id" => org_id)
+  }
 
   def self.to_csv(hxl: false)
     fields = %w(org country age gender mood_rating description story created_at)
@@ -46,7 +49,17 @@ class Drawing < ActiveRecord::Base
     end
   end
 
-  def viewer_can_change?(viewer)
-    viewer.organisation == user.organisation
+  def can_view?(current_user)
+    super_admin_or_same_org?(current_user)
+  end
+
+  def can_modify?(current_user)
+    super_admin_or_same_org?(current_user)
+  end
+
+  private
+
+  def super_admin_or_same_org?(current_user)
+    current_user.super_admin? || current_user.organisation_id == user.organisation_id
   end
 end

--- a/app/views/drawings/_drawings.html.haml
+++ b/app/views/drawings/_drawings.html.haml
@@ -20,11 +20,11 @@
     %td
       = drawing.mood_rating
     %td
-      - if drawing.viewer_can_change?(current_user)
+      - if drawing.can_modify?(current_user)
         = link_to edit_drawing_path(drawing) do
           %i.fa.fa-pencil{"aria-hidden" => "true"}
     %td
-      - if drawing.viewer_can_change?(current_user)
+      - if drawing.can_modify?(current_user)
         = link_to drawing_path(drawing.id), method: :delete, data: { confirm: 'Are you sure?' } do
           %i.fa.fa-trash{"aria-hidden" => "true"}
     %td

--- a/app/views/drawings/show.html.haml
+++ b/app/views/drawings/show.html.haml
@@ -1,6 +1,6 @@
 = render 'drawing', drawing: @drawing
 .text-center.edit-links
   = link_to "Back To List", drawings_path
-  - if @drawing.viewer_can_change?(current_user)
+  - if @drawing.can_modify?(current_user)
     |
     = link_to "Edit Drawing", edit_drawing_path(@drawing)

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -27,7 +27,7 @@
                 %li
                   = link_to "Users", users_path
               %li
-                = link_to "Organisations", organisations_path
+                = link_to "Organisations", organisations_path if current_user.super_admin?
               %li
                 = link_to "Logout", destroy_user_session_path, method: :delete
         - else

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -1,7 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe OrganisationsController, type: :controller do
-  login_as_admin
+  login_as_super_admin
+
+  shared_examples_for "an unauthorized user" do
+    context "with incorrect access" do
+      login_as_admin
+
+      it "redirects to root path" do
+        expect(perform).to redirect_to root_path
+      end
+
+      it "renders a flash error" do
+        perform
+        expect(flash[:error]).to have_content("Sorry, you may be a super human being, but you need to be a super admin to do that.")
+      end
+    end
+  end
 
   describe "GET index" do
     subject(:perform) { get :index }
@@ -12,6 +27,8 @@ RSpec.describe OrganisationsController, type: :controller do
       expect(assigns(:organisations)).not_to be_nil
     end
     it { expect(perform).to render_template :index }
+
+    it_behaves_like "an unauthorized user"
   end
 
   describe "GET show" do
@@ -24,6 +41,8 @@ RSpec.describe OrganisationsController, type: :controller do
       expect(assigns(:organisation)).not_to be_nil
     end
     it { expect(perform).to render_template :show }
+
+    it_behaves_like "an unauthorized user"
   end
 
   describe "POST create" do
@@ -53,6 +72,8 @@ RSpec.describe OrganisationsController, type: :controller do
         expect(response).to render_template :new
       end
     end
+
+    it_behaves_like "an unauthorized user"
   end
 
   describe "PUT update" do
@@ -85,5 +106,7 @@ RSpec.describe OrganisationsController, type: :controller do
         expect(response).to render_template :edit
       end
     end
+
+    it_behaves_like "an unauthorized user"
   end
 end

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -55,4 +55,49 @@ RSpec.describe Drawing, type: :model do
       end
     end
   end
+
+  shared_examples_for "a method that asserts a super admin or user in same org" do
+    let(:instance) { FactoryGirl.create(:drawing) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    context "user is super_admin" do
+      before do
+        user.role = "super_admin"
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "user is not super admin" do
+      context "user has matching organisation id" do
+        before do
+          user.role = "admin"
+          user.organisation_id = instance.user.organisation_id
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "user does not have matching organisation id" do
+        before do
+          user.role = "admin"
+          user.organisation_id = instance.user.organisation_id + 1
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe "#can_view?" do
+    subject { instance.can_view?(user) }
+
+    it_behaves_like "a method that asserts a super admin or user in same org"
+  end
+
+  describe "#can_modify?" do
+    subject { instance.can_modify?(user) }
+
+    it_behaves_like "a method that asserts a super admin or user in same org"
+  end
 end


### PR DESCRIPTION
This updates the permissions around viewing, editing or deleting drawings, restricting access to Super Admins OR those within the same organisation.

It also restricts viewing, editing or deleting Organisations to Super Admins only.

_NB: At this time, all of the urgent role permissions we need for a next pilot involving a second organisation are implemented. However, the Org Admin level is still exactly the same as a normal admin, so there is still a separate ticket (TODO write up) / task left to adjust Org Admin levels to allow them to access and create users - but only in their organisation. Super Admins will need to add new users in the meantime._

#### Addresses issue: #149

## What this does
- [x] Viewing drawings index:
  - [x] Add a new scope to the Drawing model to filter drawings by org ID
  - [x] Update the Drawings controller to restrict to super admins or use the new scope
- [x] Viewing/updating/deleting a single drawing:
  - [x] Update the Drawing model with two methods checking view and edit rules, taking into account user role and organisations
  - [x] Update the drawings controller to use the new model methods above, redirect to homepage with appropriate errors if access is denied
- [x] Restrict all Organisation access to Super Admins only with authorize method

## Screenshots

### Super admin (access to all drawings and orgs):

<img width="1234" alt="screen shot 2017-03-05 at 23 45 01" src="https://cloud.githubusercontent.com/assets/574526/23592812/2378cbaa-01fe-11e7-8641-bd1dbdae2fd2.png">

<img width="1256" alt="screen shot 2017-03-06 at 00 08 19" src="https://cloud.githubusercontent.com/assets/574526/23593062/c86eb7e8-0201-11e7-9ac8-c3ab00083295.png">


### Admin or Org admin (access to all drawings within org + no access to edit orgs):

<img width="1265" alt="screen shot 2017-03-05 at 23 44 19" src="https://cloud.githubusercontent.com/assets/574526/23592813/2b096cbc-01fe-11e7-9590-e793e664d341.png">

<img width="548" alt="screen shot 2017-03-06 at 00 08 27" src="https://cloud.githubusercontent.com/assets/574526/23593066/d8f217cc-0201-11e7-8342-e49b51b584de.png">


### Attempt to view an unauthorized drawing by accessing URL directly:

<img width="1211" alt="screen shot 2017-03-05 at 23 45 49" src="https://cloud.githubusercontent.com/assets/574526/23592814/3491f128-01fe-11e7-8ae6-efab12b0f8c8.png">

### Attempt to edit/delete an unauthorized drawing by accessing URL directly:

<img width="1233" alt="screen shot 2017-03-05 at 23 46 35" src="https://cloud.githubusercontent.com/assets/574526/23592817/396f52d0-01fe-11e7-9c92-83f072c481eb.png">

### Attempt to access/edit organisations when unauthorized

<img width="1241" alt="screen shot 2017-03-06 at 00 13 15" src="https://cloud.githubusercontent.com/assets/574526/23593071/e82f9ac0-0201-11e7-847c-b0a18f839170.png">

