### PR TITLE
Adds timeframe to confirmation email

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -2,5 +2,9 @@
   Welcome #{@email}!
 %p You have been invited to contribute to the Draw My Life admin portal, collecting drawings and data to support children in crisis.
 
-%p Please click the link below to confirm your Draw My Life  account email and set your password:
+%p
+  Please click the link below
+  - unless Devise.confirm_within.nil?
+    %b within #{time_ago_in_words(Devise.confirm_within.seconds.from_now)}
+  to confirm your Draw My Life account email address and set your password:
 %p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -5,6 +5,6 @@
 %p
   Please click the link below
   - unless Devise.confirm_within.nil?
-    %b within #{time_ago_in_words(Devise.confirm_within.seconds.from_now)}
+    %b within #{Devise.confirm_within.inspect}
   to confirm your Draw My Life account email address and set your password:
 %p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -26,7 +26,7 @@ en:
       unlock_instructions:
         subject: "Draw My Life: Unlock instructions"
       password_change:
-        subject: "Draw My Life: Password Changed"
+        subject: "Draw My Life: Password changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,13 +20,13 @@ en:
       deleted_account: "This account does not exist or has been deleted."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Welcome to Draw My Life! Please confirm your email address"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Draw My Life: Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Draw My Life: Unlock instructions"
       password_change:
-        subject: "Password Changed"
+        subject: "Draw My Life: Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."


### PR DESCRIPTION
#### Addresses issue: #155

## What this does
- [x] Adds the timeframe that the user must confirm their email
  - [x] Uses Devise's config to set this, so even if it changes, the email will still be correct
  - [x] Does not run this code if Devise.confirm_within is set to nil
- [x] BONUS: Adds "Draw My Life: " to other email subject lines 

## Screenshots
### Before
![image](https://cloud.githubusercontent.com/assets/4599695/23822700/1a04feae-064a-11e7-9b9c-097b636b8f80.png)

### After
#### Devise.confirm_within = 7.days
![image](https://cloud.githubusercontent.com/assets/4599695/23822709/43b09164-064a-11e7-830b-a4416884b05d.png)

#### Devise.confirm_within = 4.months
![image](https://cloud.githubusercontent.com/assets/4599695/23822713/5896cdf0-064a-11e7-9271-9b5a0ffdd711.png)

#### Devise.confirm_within = nil
![image](https://cloud.githubusercontent.com/assets/4599695/23822714/6496c704-064a-11e7-96df-3a6611682b20.png)

## Deploy Instructions
No special requirements. Restart will be required if you want to change the value of Devise.confirm_within.